### PR TITLE
fix: use process.env instead of import.meta.env in src/config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ export const SITE: SiteConfig = {
   /** Public URL of the deployed site, no trailing slash. Breaks SEO/RSS if incorrect. */
   // `||` (not `??`) so an explicitly empty `SITE_URL=` in `.env` also
   // falls back to the default. Astro requires `site` to be a valid URL.
-  url: import.meta.env.SITE_URL || 'https://chirping-astro.example.com',
+  url: process.env.SITE_URL || 'https://chirping-astro.example.com',
   /** Supported locales. Changing this requires adding/removing locale folders, content, and i18n entries. */
   locales: locales,
   /** Default locale. Changing this is a breaking, atomic, multi-file operation. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import avatarImg from './assets/images/site/avatar.svg';
 import ogDefaultImg from './assets/images/site/og-default.svg';
 import type { SiteConfig, NavItem, SocialLink, GiscusConfig } from './types/config';


### PR DESCRIPTION
# Pull Request

## Summary

Replace `import.meta.env.SITE_URL` with `process.env.SITE_URL` in `src/config.ts`, to fix RSS feed links.

## Reason

`src/config.ts` is imported by `astro.config.mjs`, which runs in the Node/Astro config context before the Vite runtime is initialized.
Because of this, `import.meta.env.SITE_URL` is `undefined` during config evaluation, causing the fallback URL to be used instead.

This affects generated URLs such as RSS feed links.

Using `process.env.SITE_URL` fixes the issue since Astro already loads `.env` values into `process.env` before evaluating the config.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor/maintenance

## Validation

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`
- [x] If this PR touches SEO/RSS/sitemap/content-route behavior, I verified a full non-fast build (without `CI_SKIP_AUTO_OG_IMAGE`, `CI_SKIP_RSS_SITEMAP`, `CI_SKIP_CONTENT_COLLECTIONS`).