### PR TITLE
Add minimumReleaseAge to bunfig.toml

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,6 +6,8 @@
 exact = false
 # Save peer dependencies
 peer = true
+# Prevent supply chain attacks
+minimumReleaseAge = 86400
 
 [install.cache]
 disable = false


### PR DESCRIPTION
Added minimumReleaseAge to prevent supply chain attacks.

# Pull Request

## Summary

Good advocacy at https://daniakash.com/posts/simplest-supply-chain-defense/

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Refactor/maintenance

## Validation

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`
- [ ] If this PR touches SEO/RSS/sitemap/content-route behavior, I verified a full non-fast build (without `CI_SKIP_AUTO_OG_IMAGE`, `CI_SKIP_RSS_SITEMAP`, `CI_SKIP_CONTENT_COLLECTIONS`).

## Screenshots (if UI change)

N/A

## Checklist

- [ ] I linked related issue(s), if any.
- [x] I kept this PR focused and avoided unrelated edits.
- [ ] I updated docs/content when behavior changed.
- [ ] I confirmed i18n impact for new user-facing text.
